### PR TITLE
Fix usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,21 @@ import (
 )
 
 func main() {
-	r := tinyrouter.New()
+	router := tinyrouter.New()
 	// Same signature to http.Handle
-	r.Handle("/handle", HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	router.Handle("/handle", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, "handle\n")
 	}))
 	// Same signature to http.HandleFunc
-	r.HandleFunc("/handlefunc", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/handlefunc", func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, "handlefunc\n")
 	})
-	r.HandleFunc("/group/{groupid}/users/{userid:[0-9a-zA-Z]}", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/group/{groupid}/users/{userid:[0-9a-zA-Z]}", func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		pathVars := ctx.Value(tinyrouter.PathVarsContextKey).(map[string]string)
 		io.WriteString(w, fmt.Sprintf("group %v/user %v", pathVars["groupid"], pathVars["userid"]))
 	})
-	http.Handle("/", r)
+	http.Handle("/", router)
 
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }


### PR DESCRIPTION
- Use 'router' as a variable name because 'r' is used as http.Request.
- Fix reference error.